### PR TITLE
fix: add a license to the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "engg-handbook",
   "version": "1.0.0",
   "repository": "https://github.com/axelerant/engg-handbook.git",
+  "license": "CC-BY-NC-SA-4.0",
   "scripts": {
     "format": "prettier --write {layouts,content,archetypes}/**/*",
     "lint:md": "markdownlint {content,archetypes}/**/*.md --fix --ignore node_modules",


### PR DESCRIPTION
I am suggesting licensing content under CC-BY-NC-SA-4.0 (Creative Commons Attribution Non Commercial Share Alike 4.0 International).

Under these terms, others are free to share and adapt the content as long as it is non-commercial, attributed to us, and shared under the same license.
