### PR TITLE
ci: use yarn in CI instead of directly calling markdownlint

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,9 +31,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli
-      - run: markdownlint content/**/*.md --ignore node_modules
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install node modules
+        run: yarn
+      - name: Lint files
+        run: yarn lint
 
   # Build job
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,9 +14,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: xt0rted/markdownlint-problem-matcher@v1
-      - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli
-      - run: markdownlint content/**/*.md --ignore node_modules
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install node modules
+        run: yarn
+      - name: Lint files
+        run: yarn lint
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a break down of #12
