### PR TITLE
Removed QE for now

### DIFF
--- a/content/docs/how-we-work/qe/_index.md
+++ b/content/docs/how-we-work/qe/_index.md
@@ -1,9 +1,0 @@
----
-title: Quality Engineering
-weight: 10
-bookCollapseSection: true
----
-
-# Quality Engineering
-
-Status: _WIP_


### PR DESCRIPTION
With [this update](https://axelerant.slack.com/archives/C025BADEK/p1721885674804889) I think we might be having QE part of other areas.

In case of adding separate content as well can we have this removed for now as we are sharing this handbook with clients/new opportunities as well and I do not want to create a different perspective that we are still working on Quality.