### PR TITLE
Fix tab content rendering issue

### DIFF
--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,0 +1,9 @@
+{{- $group := printf "tabs-%d" .Parent.Ordinal -}}
+{{- $tab := printf "%s-%d" $group .Ordinal }}
+<input type="radio" class="toggle" name="{{ $group }}" id="{{ $tab }}" {{ if not .Ordinal }}checked="checked"{{ end }} />
+<label for="{{ $tab }}">
+  {{- .Get 0 -}}
+</label>
+<div class="book-tabs-content markdown-inner">
+  {{- .Inner | markdownify -}}
+</div>

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,6 +1,12 @@
 {{- $group := printf "tabs-%d" .Parent.Ordinal -}}
 {{- $tab := printf "%s-%d" $group .Ordinal }}
-<input type="radio" class="toggle" name="{{ $group }}" id="{{ $tab }}" {{ if not .Ordinal }}checked="checked"{{ end }} />
+<input
+  type="radio"
+  class="toggle"
+  name="{{ $group }}"
+  id="{{ $tab }}"
+  {{ if not .Ordinal }}checked="checked"{{ end }}
+/>
 <label for="{{ $tab }}">
   {{- .Get 0 -}}
 </label>


### PR DESCRIPTION
This PR fixes an issue where content inside tabs was not rendering correctly.

- Added the tab shortcode to ensure proper Markdown rendering within tabs. Copied the original content from https://github.com/alex-shpak/hugo-book/blob/master/layouts/shortcodes/tab.html and used `markdownify` for inner content.