### PR TITLE
feat: add script to check for non-breaking spaces in markdown files

### DIFF
--- a/.github/check_nbsp.sh
+++ b/.github/check_nbsp.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+DIRECTORY="${1:-.}"      # Default to current directory if not provided
+THRESHOLD="${2:-1}"      # Default threshold for nbsp per line
+
+found=0
+
+# Find all .md files and check each
+while read -r file; do
+  awk -v threshold="$THRESHOLD" '
+  {
+    n = gsub(" ", ""); # count of NBSPs per line
+    if (n > threshold) {
+      printf("File: %s | Line %d | Non-breaking spaces: %d\n", FILENAME, NR, n);
+      exit_code = 1;
+    }
+  }
+  END { exit (exit_code ? 1 : 0) }
+  ' "$file"
+
+  # If awk returned non-zero (found lines), set global flag
+  if [ $? -ne 0 ]; then
+    found=1
+  fi
+done <<< "$(find "$DIRECTORY" -type f -name '*.md')"
+
+# If any files were found with too many non-breaking spaces, exit with error
+if [ $found -ne 0 ]; then
+  echo "Error: Found non-breaking spaces in files exceeding the threshold of $THRESHOLD."
+  exit 1
+else
+  echo "No files found with non-breaking spaces exceeding the threshold of $THRESHOLD."
+fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,9 @@ jobs:
         run: |
           yarn lint-fix:prettier
           git diff
+      - name: Check for non-breaking spaces
+        run: |
+          ./github/check_nbsp.sh content/ 5
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
           git diff
       - name: Check for non-breaking spaces
         run: |
-          ./github/check_nbsp.sh content/ 5
+          ./.github/check_nbsp.sh content/ 5
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We found in #248 that some of the files get non-breaking spaces inadvertently and this causes problems.

This PR will hopefully avoid that problem going forward. The workflow should fail at first but then should pass once we merge #248.

