### PR TITLE
docs: add AI-Assisted Development section to the handbook

### DIFF
--- a/content/docs/how-we-work/ai-practices/_index.md
+++ b/content/docs/how-we-work/ai-practices/_index.md
@@ -1,0 +1,30 @@
+---
+title: AI-Assisted Development
+weight: 6
+bookCollapseSection: true
+description: Claude Code is our standard AI coding tool across engineering. This section covers how we set up projects, build skills, and work with AI at Axelerant.
+---
+
+# AI-Assisted Development
+
+We treat AI as a core part of how we deliver software, not a side experiment. Every engineer at Axelerant is expected to use AI tools effectively in their daily work.
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is our standard AI coding tool. It runs in the terminal, understands project context through configuration files, and integrates with the tools we already use: Jira, GitHub, Sentry, and our hosting platforms. See the [official documentation](https://docs.anthropic.com/en/docs/claude-code) for installation, setup, and feature reference.
+
+## What we cover here
+
+These pages document Axelerant's opinions and practices around AI-assisted development. For how Claude Code works technically, refer to the [official docs](https://docs.anthropic.com/en/docs/claude-code). What you'll find here is what we expect on our projects, how we've seen teams succeed, and what to avoid.
+
+## Previous tools
+
+We previously used Cline (with OpenRouter) and Cursor as IDE-based AI assistants. These tools served us well during our initial adoption of AI-assisted development. As of early 2026, Claude Code is the standard across engineering. If you encounter references to Cline, Cursor, or OpenRouter in older project documentation or Confluence pages, treat them as historical context rather than current recommendations.
+
+## Where to learn and share
+
+- **#wg-ai-native-engineering** — primary channel for Claude Code practices, skills, plugins, and project-specific learnings
+- **#guild-ai-coding-tooling-and-ideas** — broader discussions on AI tooling, experiments, and tips
+- **#wg-tool-claude** — Claude-specific working group for resources and announcements
+
+These channels are where teams share custom skills, workflow improvements, and real project outcomes. If you build something useful, share it there.
+
+{{< section-pages >}}

--- a/content/docs/how-we-work/ai-practices/development-practices.md
+++ b/content/docs/how-we-work/ai-practices/development-practices.md
@@ -33,7 +33,7 @@ If a solution from the AI isn't quickly helping or you feel you're losing contro
 Claude Code supports multiple models. Pick the right one for the task:
 
 | Task | Model |
-|------|-------|
+| ------ | ------- |
 | Complex architecture, root cause analysis | Opus |
 | Everyday tasks, most ticket work | Sonnet |
 | Simple lookups, single-file operations | Haiku |

--- a/content/docs/how-we-work/ai-practices/development-practices.md
+++ b/content/docs/how-we-work/ai-practices/development-practices.md
@@ -1,0 +1,75 @@
+---
+title: Development Practices
+weight: 3
+description: Our expectations for how engineers use AI in their daily work — what to do, what to avoid, and how to stay effective.
+---
+
+# How We Use AI in Development
+
+AI tools are powerful but they require discipline. These are our expectations for how engineers at Axelerant work with AI.
+
+## Human in the loop
+
+AI augments your capability. It does not replace your judgment. Always review AI-generated code — it's rare not to find something to fix or improve.
+
+Be aware of cognitive biases that come with AI assistance:
+
+- **Automation bias** — over-relying on AI suggestions because they look confident
+- **Anchoring** — difficulty thinking beyond the AI's initial suggestion
+- **Framing effect** — accepting the AI's phrasing or approach at face value
+- **Sunk cost fallacy** — reluctance to discard AI-generated code you've already invested time reviewing
+
+If a solution from the AI isn't quickly helping or you feel you're losing control, revert the changes and try a different approach. Sometimes writing the code yourself is faster.
+
+## Session discipline
+
+- **Use `/clear` between tasks.** Stale conversation history wastes tokens and can confuse context.
+- **Separate implementation from review.** If you ask Claude to build a feature and then review it in the same session, it will also review all the failed attempts and exploratory work. Instead, do a `git diff` and review in a separate session for objectivity.
+- **Use Plan Mode for complex work.** For multi-file changes or architectural decisions, use Shift+Tab to enter Plan Mode before implementation. This prevents expensive rework.
+- **Use `/effort` for simple tasks.** Deep reasoning on a single-file change wastes tokens. Lower the thinking budget when the task is straightforward.
+
+## Model selection
+
+Claude Code supports multiple models. Pick the right one for the task:
+
+| Task | Model |
+|------|-------|
+| Complex architecture, root cause analysis | Opus |
+| Everyday tasks, most ticket work | Sonnet |
+| Simple lookups, single-file operations | Haiku |
+
+## Token efficiency
+
+Every token costs money and context space. A few habits that help:
+
+- Keep [CLAUDE.md under 200 lines]({{< relref "project-setup" >}}) — it loads on every session
+- Disconnect unused MCP servers (`/mcp` to manage)
+- Use [skills]({{< relref "skills-and-workflows" >}}) for repeated workflows — they load only when called
+- Reference files by path instead of pasting content into the chat
+- Use sub-agents for large tasks: Claude can spawn parallel agents instead of doing everything in one context window
+
+## Data protection
+
+These rules are non-negotiable:
+
+- **Use only company-approved tools and subscriptions.** No free or personal accounts for work.
+- **Never share client code, proprietary data, or credentials** with any AI tool.
+- **Sanitize sensitive data** before sharing context, even with providers that claim data won't be used for training. If you need to query sensitive logic, reformulate it to be generic and anonymized.
+- **Be transparent with clients** about AI usage. Acknowledge their concerns and follow any client-specific policies.
+
+## Workflow integration
+
+AI works best when it's connected to the systems we already use:
+
+- **Jira** — always read the ticket (including comments) before starting work. Use the Atlassian MCP connector when available to pull ticket context directly.
+- **Slack** — reference relevant Slack threads for decision context when discussing implementation approaches.
+- **Git** — work on feature branches. Never push directly to `main` or `master`. Use separate sessions for PR creation and review.
+- **Sentry** — check Sentry for error context before debugging production issues.
+
+## Open source contributions
+
+When contributing to open source projects, be especially thoughtful about AI-generated code. See our [open source contribution guidelines]({{< relref "../open-source-contribution" >}}) for more on responsible use of automated tools in community contributions.
+
+## Sharing what you learn
+
+We improve our AI practices through shared experience. When you discover something that works well — a skill that saves time, a workflow pattern, a model selection insight — share it in **#wg-ai-native-engineering** on Slack. These learnings feed back into our project configurations, shared skills, and this handbook.

--- a/content/docs/how-we-work/ai-practices/project-setup.md
+++ b/content/docs/how-we-work/ai-practices/project-setup.md
@@ -1,0 +1,62 @@
+---
+title: Project Configuration
+weight: 1
+description: Every project at Axelerant should include Claude Code configuration committed to the repository so the entire team works with shared context, permissions, and tooling.
+---
+
+# Project-Level AI Configuration
+
+Claude Code reads configuration from the project directory. When this configuration is committed to the repository, every team member starts with the same context, permissions, and tool integrations. This is no different from how we treat DDEV configuration or linting rules — it's part of the project, not a personal preference.
+
+See the [official documentation on memory and project configuration](https://docs.anthropic.com/en/docs/claude-code/memory) for how these files work.
+
+## What every project should have
+
+### CLAUDE.md
+
+A project-level `.claude/CLAUDE.md` (or `CLAUDE.md` at the repo root) gives Claude context about the project: the stack, architecture patterns, conventions, and common pitfalls.
+
+Our recommendation: keep this file under 200 lines. It loads on every session, so anything in it costs tokens on every interaction. Reference [skills]({{< relref "skills-and-workflows" >}}) for detailed workflows instead of inlining everything here.
+
+Good things to include:
+
+- The stack and key architectural decisions
+- Conventions that aren't obvious from the code (naming patterns, file organization)
+- Common mistakes to avoid on this specific project
+- Commands to run for building, testing, and linting
+
+Things to leave out:
+
+- General programming knowledge (Claude already knows this)
+- Content that duplicates what's in the code or README
+- Long architecture diagrams or troubleshooting guides (put these in rules or skills)
+
+### Settings and permissions
+
+`.claude/settings.json` stores project-level permissions. Without this, every new session starts from scratch on what commands Claude is allowed to run. Define the permissions once and commit them.
+
+### MCP server configuration
+
+`.claude/.mcp.json` defines which [MCP servers](https://modelcontextprotocol.io/) are available in the project. Common ones we use:
+
+- **Atlassian** — for reading Jira tickets and Confluence pages directly from Claude
+- **Playwright** — for browser automation and visual testing
+- **Figma** — for design-to-code workflows on decoupled projects
+
+Only configure the MCP servers the project actually uses. Each connected server adds tool definitions to the context window. Run `/mcp` in Claude Code to see what's active and disable anything idle.
+
+### Ignore file
+
+`.claudeignore` excludes directories and files from Claude's indexing. Always exclude `node_modules`, `vendor`, large SQL dumps, and other files that would waste context. This follows the same pattern as `.gitignore`.
+
+### Scoped rules
+
+`.claude/rules/*.md` files contain instructions that activate only when touching specific paths. For example, a rule that only applies when editing files under `src/api/` or a Drupal-specific rule for custom modules. This keeps the main CLAUDE.md lean while still providing targeted guidance.
+
+## Commit these files
+
+All of the above should be committed to the repository. When a new team member clones the project, they get the full AI configuration without any manual setup.
+
+## Global configuration
+
+Engineers may also maintain a global `~/.claude/CLAUDE.md` that applies across all projects. This is personal — it might include your preferred model settings, general coding style preferences, or workflow habits. The [official docs on configuration hierarchy](https://docs.anthropic.com/en/docs/claude-code/settings) cover how global and project settings interact.

--- a/content/docs/how-we-work/ai-practices/skills-and-workflows.md
+++ b/content/docs/how-we-work/ai-practices/skills-and-workflows.md
@@ -1,0 +1,60 @@
+---
+title: Skills and Workflows
+weight: 2
+description: We encode our delivery processes into reusable Claude Code skills so that project knowledge accumulates over time instead of starting from scratch every session.
+---
+
+# Skills and Automated Workflows
+
+The difference between using Claude Code conversationally and using it effectively is skills. A skill is a structured instruction set that tells Claude exactly how to approach a specific type of work on a project. Instead of explaining your project's conventions every session, you encode them once and invoke them by name.
+
+For how skills work technically, see the [official skills documentation](https://docs.anthropic.com/en/docs/claude-code/skills).
+
+## Our approach: skills as institutional knowledge
+
+We treat skills as the place where project-specific knowledge lives. A good skill encodes:
+
+- **Project conventions** — the architecture patterns, naming rules, and file organization that are specific to this project
+- **Past mistakes** — things that went wrong and what the skill should do differently
+- **Quality gates** — verification steps that must pass before the skill considers its work done
+
+Skills load on demand, not on every message. This makes them a better place for detailed workflows than CLAUDE.md, which loads every time.
+
+## Iteration logs
+
+The most impactful practice we've found is maintaining iteration logs inside skills. After every use of a skill, record what went well, what broke, and what to do differently next time. The skill evolves with every use — Claude doesn't repeat mistakes because the fix is encoded in the skill itself.
+
+Teams on our PRM project saw Figma-to-code workflows improve significantly over successive iterations: each round of learnings reduced redundant API calls, improved component reuse, and eliminated repeated errors.
+
+## Examples from our projects
+
+### Drupal SDLC Plugin
+
+The [Drupal SDLC Plugin](https://axelerant.atlassian.net/wiki/spaces/AH/pages/5886083085) is a Claude Code plugin built for Drupal projects at Axelerant. It ships with 11 skills covering the full development lifecycle:
+
+- `/work-on-jira-ticket` — reads a Jira ticket, generates a spec, builds, validates, tests, and raises a PR
+- `/spec-writer` — converts a ticket or description into a structured spec with acceptance criteria and test mapping
+- `/config-builder` — generates Drupal config YAML from natural language
+- `/validate` — runs the complete quality gate: PHP lint, GrumPHP, config round-trip, visual screenshots, tests
+- `/pr-reviewer` — reviews a PR diff for security, AC coverage, and risk
+
+The plugin also includes hooks that block writes to protected files and run PHP syntax checks on every edit. See the [full documentation on Confluence](https://axelerant.atlassian.net/wiki/spaces/AH/pages/5886083085) for setup and usage.
+
+### Project-specific skill catalogs
+
+Several teams have built skill catalogs tailored to their projects:
+
+- **PRM (Next.js + Magento)** — 10 skills covering Figma-to-UI, API integration, unit and e2e test generation, ticket-to-PR automation, and Jira task creation
+- **CDM teams** — skills for Pattern Lab scaffolding, Drupal integration, implementation details generation, and structured code review
+
+These catalogs are shared in **#wg-ai-native-engineering** on Slack. If you build skills that could benefit other teams, share them there.
+
+## Building your own skills
+
+Start with the tasks your team repeats most often. A good first skill is usually one that:
+
+- Follows a consistent sequence of steps every time
+- Requires project-specific knowledge that Claude wouldn't know on its own
+- Has clear verification criteria (tests pass, lint is clean, config is valid)
+
+The [official documentation](https://docs.anthropic.com/en/docs/claude-code/skills) covers the technical format. What matters more is the content: be specific about your project's patterns, include the mistakes you've learned from, and define what "done" looks like.

--- a/content/docs/how-we-work/baseline/_index.md
+++ b/content/docs/how-we-work/baseline/_index.md
@@ -220,9 +220,15 @@ Read more details [here]({{< relref "logging-details.md" >}}).
 
 ## Functional Testing
 
-We automate our tests using [Cypress](https://www.cypress.io/). We focus more on functional testing rather than unit testing because this is more of a fit for a typical project at Axelerant. Unit testing has its place and we should write unit tests but we recognize that writing tests introduces a cognitive load. To limit the number of paradigms that people have to deal with, we are limiting ourselves to the most impactful kind of tests and that is a functional test run in a browser-like environment.
+We automate our tests using [Playwright](https://playwright.dev/) and [Cypress](https://www.cypress.io/) with increased preference to Playwright. We focus more on functional testing rather than unit testing because this is more of a fit for a typical project at Axelerant. Unit testing has its place and we should write unit tests but we recognize that writing tests introduces a cognitive load. To limit the number of paradigms that people have to deal with, we are limiting ourselves to the most impactful kind of tests and that is a functional test run in a browser-like environment.
 
 We maintain a set of [template test scripts](https://github.com/contrib-tracker/backend/tree/main/web/themes/custom/contribtracker/cypress/e2e) to accelerate the setup and implementation of functional tests across projects. These scripts are tagged based on various scenarios to select which tests to run depending on the scenario. Tagging ensures an efficient testing process by focusing on relevant scripts during development and continuous integration. These tests must run via CI but should also be run locally before pushing the changes. A CI run example may be found in [the contrib-tracker example pipeline](https://github.com/contrib-tracker/backend/blob/main/.github/workflows/ci.yml).
+
+## AI-Assisted Development
+
+Claude Code is our standard AI coding tool. As part of the project baseline, include AI configuration files in the repository so that the entire team works with shared context and permissions. At a minimum, this includes a `.claude/CLAUDE.md` with project-specific context, `.claude/settings.json` for shared permissions, and `.claude/.mcp.json` for relevant MCP server integrations.
+
+See our [AI-Assisted Development]({{< relref "../ai-practices" >}}) guide for detailed recommendations on project setup, skills, and development practices.
 
 ## Reverse Proxy
 

--- a/content/docs/how-we-work/local-tools.md
+++ b/content/docs/how-we-work/local-tools.md
@@ -42,6 +42,10 @@ We use JIRA for updating the ticket status and progress.
 
 Using extensions to do the above right from the IDE allows for better collaboration, less turn around times for PR reviews and more accurate time logging and ticket updates.
 
+### AI Coding Tools
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is our standard AI coding tool for development work. It runs in the terminal, integrates with our project tooling, and supports project-level configuration that the whole team shares. See our [AI-Assisted Development]({{< relref "ai-practices" >}}) section for how we set up projects, build skills, and work with AI at Axelerant.
+
 ### Development environments
 
 Development environments are trickier to maintain as per individual preferences and that is why the team usually opts for a single development environment (configured in the project repository). Our choice of development environments is [DDEV](https://ddev.readthedocs.io/en/stable/users/install/) and we have tooling to improve some of our processes.

--- a/content/docs/principles/automate.md
+++ b/content/docs/principles/automate.md
@@ -13,3 +13,5 @@ Automation solutions are often used to improve code quality, boost productivity,
 ## Generative AI
 
 With Generative AI, software development is being constantly redefined. As many people say, "AI will not replace you but software engineers who use AI will replace you." We must understand the benefits and limitations of the current generation of Generative AI if we are serious about providing value in the world of information technology.
+
+At Axelerant, AI-assisted development is not optional — it's a core part of how we deliver. We've standardized on [Claude Code](https://docs.anthropic.com/en/docs/claude-code) as our primary AI coding tool and have built practices around project configuration, reusable skills, and effective workflows. See our [AI-Assisted Development]({{< relref "../how-we-work/ai-practices" >}}) guide for our current practices and expectations.


### PR DESCRIPTION
Axelerant has standardized on Claude Code as the primary AI coding
tool. The handbook had no content covering AI practices. This adds a
new "AI-Assisted Development" section under How We Work with pages on
project configuration, skills and workflows, and development practices.

Existing pages (local-tools, automate, baseline) are updated with
cross-references to the new section. Previous tools (Cline, Cursor,
OpenRouter) are noted as deprecated in favor of Claude Code.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
